### PR TITLE
Add the "parentName" property

### DIFF
--- a/src/Nodes/XMLNode.php
+++ b/src/Nodes/XMLNode.php
@@ -11,6 +11,7 @@ abstract class XMLNode
         public string  $name,
         public array   $attributes = [],
         public ?string $content = null,
+        public ?string $parentName = null,
     ) {
     }
 }

--- a/src/Nodes/XMLNodeClose.php
+++ b/src/Nodes/XMLNodeClose.php
@@ -5,8 +5,9 @@ namespace Elecena\XmlIterator\Nodes;
 class XMLNodeClose extends XMLNode
 {
     public function __construct(
-        string $name
+        string $name,
+        ?string $parentName,
     ) {
-        parent::__construct($name, attributes: [], content: null);
+        parent::__construct($name, attributes: [], content: null, parentName: $parentName);
     }
 }

--- a/src/Nodes/XMLNodeOpen.php
+++ b/src/Nodes/XMLNodeOpen.php
@@ -5,9 +5,10 @@ namespace Elecena\XmlIterator\Nodes;
 class XMLNodeOpen extends XMLNode
 {
     public function __construct(
-        string $name,
-        array  $attributes,
+        string  $name,
+        array   $attributes,
+        ?string $parentName,
     ) {
-        parent::__construct($name, $attributes, content: null);
+        parent::__construct($name, $attributes, content: null, parentName: $parentName);
     }
 }

--- a/src/XMLParser.php
+++ b/src/XMLParser.php
@@ -88,6 +88,7 @@ class XMLParser implements \Iterator
         $this->nodesQueue[] = new Nodes\XMLNodeOpen(
             name: $this->currentTagName,
             attributes: $this->currentTagAttributes,
+            parentName: end($this->nodeNamesStack) ?: null
         );
 
         $this->nodeNamesStack[] = $tagName;
@@ -100,18 +101,20 @@ class XMLParser implements \Iterator
             name: $this->currentTagName,
             attributes: $this->currentTagAttributes,
             content: $tagContent,
+            parentName: array_slice($this->nodeNamesStack, -2, 1)[0] ?: null
         );
     }
 
     public function endXML(\XMLParser $parser, string $tagName): void
     {
+        // Pop the node name off the end of stack
+        array_pop($this->nodeNamesStack);
+
         // append to the queue of items to iterate over
         $this->nodesQueue[] = new Nodes\XMLNodeClose(
             name: $tagName,
+            parentName: end($this->nodeNamesStack) ?: null
         );
-
-        // Pop the node name off the end of stack
-        array_pop($this->nodeNamesStack);
 
         // and update the current tag name to properly handle consecutive closing tag and whitespaces
         // e.g. </foo>\n\n</bar>

--- a/tests/XMLParserCDataTest.php
+++ b/tests/XMLParserCDataTest.php
@@ -37,5 +37,6 @@ XML);
 
         $this->assertInstanceOf(XMLNodeContent::class, $node);
         $this->assertStringStartsWith("<p>\n      <a href=\"/mylink/article1\">", trim($node->content));
+        $this->assertEquals('item', $node->parentName);
     }
 }

--- a/tests/XMLParserLargeFileTest.php
+++ b/tests/XMLParserLargeFileTest.php
@@ -35,6 +35,7 @@ class XMLParserLargeFileTest extends XMLParserTestCase
         foreach($this->getParser()->iterateByNodeContent(name: 'loc') as $node) {
             $this->assertInstanceOf(XMLNodeContent::class, $node);
             $this->assertEquals('loc', $node->name);
+            $this->assertEquals('url', $node->parentName);
             $this->assertStringStartsWith('http', $node->content);
 
             $cnt++;

--- a/tests/XMLParserTest.php
+++ b/tests/XMLParserTest.php
@@ -24,6 +24,7 @@ class XMLParserTest extends XMLParserTestCase
 
         $this->assertInstanceOf(XMLNodeOpen::class, $sitemapIndex);
         $this->assertEquals('sitemapindex', $sitemapIndex->name);
+        $this->assertNull($sitemapIndex->parentName, 'Root nodes will get null as their parent');
         $this->assertEquals('http://www.sitemaps.org/schemas/sitemap/0.9', $sitemapIndex->attributes['xmlns'] ?? null);
     }
 
@@ -39,6 +40,7 @@ class XMLParserTest extends XMLParserTestCase
 
         $this->assertInstanceOf(XMLNodeClose::class, $closingTag);
         $this->assertEquals('sitemapindex', $closingTag->name);
+        $this->assertNull($closingTag->parentName);
     }
 
     public function testParsesTheLocNodes(): void
@@ -48,6 +50,7 @@ class XMLParserTest extends XMLParserTestCase
         foreach($this->getParser() as $item) {
             if ($item instanceof XMLNodeContent && $item->name === 'loc') {
                 $locations[] = $item->content;
+                $this->assertEquals('sitemap', $item->parentName);
             }
         }
 

--- a/tests/XMLParserWhitespacesTest.php
+++ b/tests/XMLParserWhitespacesTest.php
@@ -30,5 +30,6 @@ XML);
 
         $this->assertCount(1, $locNodesContent);
         $this->assertEquals('https://elecena.pl/sitemap-001-search.xml.gz', $locNodesContent[0]->content);
+        $this->assertEquals('sitemap', $locNodesContent[0]->parentName);
     }
 }


### PR DESCRIPTION
It will return `null` for the XML root nodes.

Will simplify XML sitemaps (and sub-sitemaps) parsing:

```xml
<sitemap><loc>https://foo.com/wp-sitemap-posts-page-1.xml</loc></sitemap>
```
vs

```xml
<url><loc>https://foo.com/page.html</loc></url>
```