### PR TITLE
Add the support for PHP 8.4

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -19,7 +19,8 @@ jobs:
         php-versions:
         - '8.1'
         - '8.2'
-        - '8.3'  # nightly
+        - '8.3'
+        - '8.4'
 
     steps:
     - uses: actions/checkout@v3

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
       "php": "^8.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^10.3",
+        "phpunit/phpunit": "^10.3 || ^11.5",
         "friendsofphp/php-cs-fixer": "^3.22"
     },
     "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "331567764171bde442b7efcdc3f90583",
+    "content-hash": "04e8d6e2022f043fa7e2a13e4bb0fcac",
     "packages": [],
     "packages-dev": [
         {
@@ -3578,13 +3578,13 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "ext-xml": "*",
         "php": "^8.1"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/src/XMLParser.php
+++ b/src/XMLParser.php
@@ -62,9 +62,8 @@ class XMLParser implements \Iterator
          * Once the iterator goes through them all, the self::next() method
          * will read and parse the next portion of the input XML stream.
          */
-        xml_set_object($this->parser, $this);
-        xml_set_element_handler($this->parser, 'startXML', 'endXML');
-        xml_set_character_data_handler($this->parser, 'charXML');
+        xml_set_element_handler($this->parser, [$this,'startXML'], [$this, 'endXML']);
+        xml_set_character_data_handler($this->parser, [$this,'charXML']);
 
         // @see https://www.php.net/manual/en/function.xml-parser-set-option.php
         xml_parser_set_option($this->parser, XML_OPTION_CASE_FOLDING, false);


### PR DESCRIPTION
## Fix deprecations

```
Deprecated: Function xml_set_object() is deprecated since 8.4, provide a proper method callable to xml_set_*_handler() functions in xml-iterator/src/XMLParser.php on line 65
Deprecated: xml_set_element_handler(): Passing non-callable strings is deprecated since 8.4 in xml-iterator/src/XMLParser.php on line 66
Deprecated: xml_set_character_data_handler(): Passing non-callable strings is deprecated since 8.4 in xml-iterator/src/XMLParser.php on line 67
```

> https://github.com/php/php-src/commit/25b4696530c5dfad6b04a57c274200beec51ab0d

* https://www.php.net/manual/en/function.xml-set-object.php